### PR TITLE
publish package to pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Wall-E
+# Wall-E aka package-sieve
 Collector of absolute 3rd party packages from existing projects
 
-![wall-e](assets/img.jpg)
+![package-sieve](assets/img.jpg)
 
 ## Background
 This project aims to generate `requirements.txt` file for existing repositories where you have an old file which is filled with dependencies of dependencies. 
@@ -10,14 +10,15 @@ This project aims to generate `requirements.txt` file for existing repositories 
 Wall-E uses `ast` module of python to parse nodes of any python script. Once the modules are retrieved, `pkg_resources` helps to find the right project name and version of the application installed. 
 
 ## Install
-Install from source
+
 ```console
-git clone https://github.com/FluffyDietEngine/wall-e
-cd wall-e
-python3 setup.py install 
+pip3 install package-sieve 
 ```
 
 ## Usage 
 ```console
-wall-e --project_folder /absolute/path/to/folder --exclude venv,__pycache__,__init__.py
+package-sieve --project_folder /absolute/path/to/folder --exclude venv,__pycache__,__init__.py
 ```
+> NOTE:  
+If you get this error `ModuleNotFoundError: No module named 'pkg_resources'`
+Just run `pip3 install setuptools` 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ HERE = pathlib.Path(__file__).parent
 DESCRIPTION = (HERE / "README.md").read_text()
 
 setup(
-    name = 'wall-e',
+    name = 'package-sieve',
     version = '0.1',
     description = 'Collector of absolute 3rd party packages from existing projects',
     long_description = DESCRIPTION,
@@ -30,8 +30,8 @@ setup(
     include_package_data=True,
     entry_points={
         "console_scripts":[
-            "wall-e=src.wall_e:main",
+            "package-sieve=src.wall_e:main",
         ]
     },
-    keywords='wall-e,ci,automation,linter,stale-package-remover',
+    keywords='package-sieve,wall-e,ci,automation,linter,stale-package-remover',
 )


### PR DESCRIPTION
- `wall-e` name already exist on pypi so had to rename it to `package-sieve` https://pypi.org/project/package-sieve
- updated `README.md` and `setup.py` with required changes
- from now on command will be `package-sieve` not `wall-e` Note: if you want command to be someting simple please let me know :)